### PR TITLE
Add adt bot to build and deploy

### DIFF
--- a/esbuild-script.mjs
+++ b/esbuild-script.mjs
@@ -8,7 +8,7 @@ import esbuild from 'esbuild';
 import fastGlob from 'fast-glob';
 
 // Find all TypeScript files in your source directory
-const entryPoints = fastGlob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));
+const entryPoints = fastGlob.sync('./src/**/*.*ts').filter((file) => !file.endsWith('test.ts'));
 
 const botLayerDeps = Object.keys(botLayer.dependencies);
 

--- a/scripts/deploy-bots.ts
+++ b/scripts/deploy-bots.ts
@@ -51,6 +51,9 @@ const BOTS: BotDescription[] = [
     extension: [getSubscriptionExtension('create')],
     questionnaires: ['patient-bed-assignment-questionnaire'],
   },
+  {
+    name: 'adt-processing-bot',
+  },
 ];
 
 async function uploadBots(): Promise<void> {
@@ -169,7 +172,10 @@ function getSubscriptionExtension(valueCode: 'create' | 'update' | 'delete' | un
 }
 
 function readBotFiles(description: BotDescription): Record<string, BundleEntry> {
-  const sourceFile = fs.readFileSync(`src/bots/${description.name}.ts`);
+  const tsPath = `src/bots/${description.name}.ts`;
+  const ctsPath = `src/bots/${description.name}.cts`;
+  const sourcePath = fs.existsSync(ctsPath) ? ctsPath : tsPath;
+  const sourceFile = fs.readFileSync(sourcePath);
   const distFile = fs.readFileSync(`dist/bots/${description.name}.js`);
 
   const srcEntry: BundleEntry = {


### PR DESCRIPTION
## Summary
Updated scripts to build and deploy bots to include `adt-processing-bot`.

## Changes
- Changed regex to include cts file in bots build script
- Added `adt-processing-bot` to bots deploy script