### PR TITLE
Remove last hard coded id

### DIFF
--- a/scripts/update-locations.cts
+++ b/scripts/update-locations.cts
@@ -1,6 +1,6 @@
 import { MedplumClient } from '@medplum/core';
 
-const parentOrgId = 'ba836894-122f-42d0-874b-83ea9557e4f3';
+const parentOrgName = 'SampleMed';
 
 async function main(): Promise<void> {
   if (!(process.env.MEDPLUM_CLIENT_ID && process.env.MEDPLUM_CLIENT_SECRET)) {
@@ -14,9 +14,14 @@ async function main(): Promise<void> {
     clientSecret: process.env.MEDPLUM_CLIENT_SECRET,
   });
 
+  const parentOrg = await medplum.searchOne('Location', { name: parentOrgName });
+  if (!parentOrg) {
+    throw new Error(`No Location found with name "${parentOrgName}"`);
+  }
+
   // Get all LEVEL-type Location
   const locations = await medplum.searchResources('Location', {
-    partof: `Location/${parentOrgId}`,
+    partof: `Location/${parentOrg.id}`,
     'physical-type': 'lvl',
   });
   for (const location of locations) {

--- a/src/components/BedStatsWidget/BedStatsWidget.tsx
+++ b/src/components/BedStatsWidget/BedStatsWidget.tsx
@@ -5,7 +5,7 @@ import { Bundle, Location } from '@medplum/fhirtypes';
 import { useMedplum, useSubscription } from '@medplum/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-const parentOrgId = 'ba836894-122f-42d0-874b-83ea9557e4f3';
+const parentOrgName = 'SampleMed';
 
 // We pulled this out because it prevents the object from being recreated on every re-render
 // It also makes us hit the fast path for `deepEquals` of object reference equality within the useSubscription hook
@@ -36,7 +36,7 @@ export function BedStatsWidget(): JSX.Element {
         const result = await medplum.graphql(
           `
       {
-        Location(id: "${parentOrgId}") {
+        LocationList(name: "${parentOrgName}") {
           id
           name
           LocationList(_reference: partof, physical_type: "lvl") {
@@ -74,7 +74,7 @@ export function BedStatsWidget(): JSX.Element {
         );
 
         const locations = [] as Location[];
-        for (const level of result.data.Location.LocationList) {
+        for (const level of result.data.LocationList[0].LocationList) {
           locations.push({ ...level });
         }
         setLocations(locations);


### PR DESCRIPTION
### Summary

- Replaced hardcoded parentOrgId (ba836894-...) with a name-based lookup using parentOrgName = 'SampleMed' in both BedStatsWidget and update-locations.cts
- BedStatsWidget now queries LocationList(name: ...) via GraphQL instead of fetching by a static ID
update-locations.cts now searches for the parent Location by name before querying its children, throwing a descriptive error if not found

`SampleMed` is the organization created when running the upsert core data command