### PR TITLE
Add github pages deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Cache node modules
         uses: actions/cache@v4
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Restore cache
         uses: actions/cache@v4
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Restore cache
         uses: actions/cache@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['main']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create app .env file
+        working-directory: .
+        run: |
+          cat > .env << EOF
+          MEDPLUM_BASE_URL=${{ secrets.MEDPLUM_BASE_URL }}
+          MEDPLUM_CLIENT_ID=${{ secrets.MEDPLUM_CLIENT_ID }}
+          MEDPLUM_PROJECT_ID=${{ secrets.MEDPLUM_PROJECT_ID }}
+          MEDPLUM_RECAPTCHA_SITE_KEY=${{ secrets.MEDPLUM_RECAPTCHA_SITE_KEY }}
+          EOF
+
+      - name: Build app
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 
 const medplum = new MedplumClient({
-  onUnauthenticated: () => (window.location.href = '/'),
+  onUnauthenticated: () => (window.location.href = '/medplum-transfer-center-demo/'),
   // baseUrl: 'http://localhost:8103/', //Uncomment this to run against the server on your localhost; also change `googleClientId` in `./pages/SignInPage.tsx`
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/medplum-transfer-center-demo/',
   plugins: [react()],
   server: {
     host: 'localhost',


### PR DESCRIPTION
# Add GitHub Pages deployment workflow and supporting app changes

## Summary

This PR enables automated deployment of the app to GitHub Pages. It includes the workflow itself plus the app-level changes required for the app to work correctly under the GitHub Pages subpath.

- Add `.github/workflows/deploy.yml` — triggers on push to `main` and on manual dispatch; builds the app using repository secrets and deploys the `dist/` folder via `actions/deploy-pages`
- Set `base: '/medplum-transfer-center-demo/'` in `vite.config.ts` so all assets resolve correctly under the GitHub Pages subpath
- Update `onUnauthenticated` redirect in `src/main.tsx` to use the full subpath `/medplum-transfer-center-demo/` instead of `/`

## Required repository secrets

The following secrets must be configured in **Settings → Secrets and variables → Actions**:

| Secret | Description |
|---|---|
| `MEDPLUM_BASE_URL` | Medplum server base URL |
| `MEDPLUM_CLIENT_ID` | Medplum client ID |
| `MEDPLUM_PROJECT_ID` | Medplum project ID |
| `MEDPLUM_RECAPTCHA_SITE_KEY` | reCAPTCHA site key |

## GitHub Pages setup

In **Settings → Pages**, set the source to **GitHub Actions**.

The current Medplum project uses an organization name other than "SampleMed". If you want to test using an existing Medplum project, you should update the organization name accordingly.